### PR TITLE
Make tuned_profile resource idempotent for action :enable

### DIFF
--- a/providers/profile.rb
+++ b/providers/profile.rb
@@ -47,6 +47,7 @@ action :enable do
   # enables profile passed in by resource call
   execute "tuned #{profile[:name]} enable" do
     command "/usr/sbin/tuned-adm profile #{profile[:name]}"
+    not_if "/usr/sbin/tuned-adm active | grep -q 'Current active profile: #{profile[:name]}'"
   end
 end
 


### PR DESCRIPTION
Without this patch, chef update running profile at each run.

Change-Id: If959e83641802e7a76548b8ef11dcf5fb04e0eed